### PR TITLE
Add ability to enable test route through config

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,5 +3,6 @@
 DefraRubyEmail::Engine.routes.draw do
   get "/test",
       to: "test#show",
-      as: "test"
+      as: "test",
+      constraints: ->(_request) { DefraRubyEmail.configuration.enabled? }
 end

--- a/lib/defra_ruby_email.rb
+++ b/lib/defra_ruby_email.rb
@@ -3,4 +3,24 @@
 require "defra_ruby_email/engine"
 
 module DefraRubyEmail
+  # Enable the ability to configure the gem from its host app, rather than
+  # reading directly from env vars. Derived from
+  # https://robots.thoughtbot.com/mygem-configure-block
+  class << self
+    attr_writer :configuration
+
+    def configuration
+      @configuration ||= Configuration.new
+    end
+
+    # Added for testing. Without we cannot test both a config object with and
+    # with set values in the same rspec session
+    def reset_configuration
+      @configuration = nil
+    end
+  end
+
+  def self.configure
+    yield(configuration)
+  end
 end

--- a/lib/defra_ruby_email/configuration.rb
+++ b/lib/defra_ruby_email/configuration.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module DefraRubyEmail
+  class Configuration
+
+    def initialize
+      @enable = false
+    end
+
+    # Controls whether the mocks are enabled. Only if set to true will the mock
+    # pages be accessible
+    def enable=(arg)
+      # We implement our own setter to handle values being passed in as strings
+      # rather than booleans
+      parsed = arg.to_s.downcase
+
+      @enable = parsed == "true"
+    end
+
+    def enabled?
+      @enable
+    end
+  end
+end

--- a/lib/defra_ruby_email/engine.rb
+++ b/lib/defra_ruby_email/engine.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require_relative "configuration"
+
 module DefraRubyEmail
   class Engine < ::Rails::Engine
     isolate_namespace DefraRubyEmail

--- a/spec/defra_ruby_email_spec.rb
+++ b/spec/defra_ruby_email_spec.rb
@@ -1,0 +1,39 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe DefraRubyEmail do
+  describe "VERSION" do
+    it "is a version string in the correct format" do
+      expect(DefraRubyEmail::VERSION).to be_a(String)
+      expect(DefraRubyEmail::VERSION).to match(/\d+\.\d+\.\d+/)
+    end
+  end
+
+  describe "#configuration" do
+    before(:each) { Helpers::Configuration.reset_for_tests }
+
+    context "when the host app has not provided configuration" do
+      let(:enabled) { false }
+
+      it "returns a DefraRubyEmail::Configuration instance with default values" do
+        expect(described_class.configuration).to be_an_instance_of(DefraRubyEmail::Configuration)
+
+        expect(described_class.configuration.enabled?).to eq(enabled)
+      end
+    end
+
+    context "when the host app has provided configuration" do
+      let(:enabled) { true }
+
+      it "returns a DefraRubyEmail::Configuration instance with matching values" do
+        described_class.configure do |config|
+          config.enable = enabled
+        end
+
+        expect(described_class.configuration).to be_an_instance_of(DefraRubyEmail::Configuration)
+        expect(described_class.configuration.enabled?).to eq(enabled)
+      end
+    end
+  end
+end

--- a/spec/requests/test_spec.rb
+++ b/spec/requests/test_spec.rb
@@ -4,14 +4,30 @@ require "rails_helper"
 
 module DefraRubyEmail
   RSpec.describe "Test", type: :request do
-    it "renders the appropriate template" do
-      get "/defra_ruby_email/test"
-      expect(response).to render_template("defra_ruby_email/test/show")
+    after(:all) { Helpers::Configuration.reset_for_tests }
+
+    let(:path) { "/defra_ruby_email/test" }
+
+    context "when mocks are enabled" do
+      before(:each) { Helpers::Configuration.prep_for_tests }
+
+      it "renders the appropriate template" do
+        get path
+        expect(response).to render_template("defra_ruby_email/test/show")
+      end
+
+      it "responds to the GET request with a 200 status code" do
+        get path
+        expect(response.code).to eq("200")
+      end
     end
 
-    it "responds to the GET request with a 200 status code" do
-      get "/defra_ruby_email/test"
-      expect(response.code).to eq("200")
+    context "when mocks are disabled" do
+      before(:all) { DefraRubyEmail.configuration.enable = false }
+
+      it "cannot load the page" do
+        expect { get path }.to raise_error(ActionController::RoutingError)
+      end
     end
   end
 end

--- a/spec/support/helpers/configuration.rb
+++ b/spec/support/helpers/configuration.rb
@@ -6,7 +6,6 @@ module Helpers
       DefraRubyEmail.reset_configuration
       DefraRubyEmail.configure do |config|
         config.enable = true
-        config.delay = delay
       end
     end
 

--- a/spec/support/helpers/configuration.rb
+++ b/spec/support/helpers/configuration.rb
@@ -2,7 +2,7 @@
 
 module Helpers
   module Configuration
-    def self.prep_for_tests(delay = 100)
+    def self.prep_for_tests
       DefraRubyEmail.reset_configuration
       DefraRubyEmail.configure do |config|
         config.enable = true

--- a/spec/support/helpers/configuration.rb
+++ b/spec/support/helpers/configuration.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+module Helpers
+  module Configuration
+    def self.prep_for_tests(delay = 100)
+      DefraRubyEmail.reset_configuration
+      DefraRubyEmail.configure do |config|
+        config.enable = true
+        config.delay = delay
+      end
+    end
+
+    def self.reset_for_tests
+      DefraRubyEmail.reset_configuration
+    end
+  end
+end


### PR DESCRIPTION
When we come to build the actual last email route, we want to be able to enable and disable it. For example this is something we want to be able to use in non-production environments, but must be inaccessible in production.

Our standard pattern is to use configuration to manage this, which would be set by the host application the engine is mounted in.

This change adds the initial config, and an example of the enable/disable feature.