### PR TITLE
Get last email body in all scenarios

### DIFF
--- a/app/mailers/defra_ruby_email/test_mailer.rb
+++ b/app/mailers/defra_ruby_email/test_mailer.rb
@@ -2,28 +2,49 @@
 
 module DefraRubyEmail
   class TestMailer < ActionMailer::Base
-    def basic_email(recipient)
+
+    FROM_ADDRESS = "defra-ruby-email@example.com"
+
+    def multipart_email(recipient, add_logo = false)
+      add_logo_attachment if add_logo
+
       mail(
         to: recipient,
-        from: "defra-ruby-email@example.com",
-        subject: "Basic email",
-        body: "This is a basic email, so calling `my_email.parts.first.body` would raise an error"
-      )
+        from: FROM_ADDRESS,
+        subject: "Multi-part email"
+      ) do |format|
+        format.html { render html: "<h1>This is the html version of an email</h1>".html_safe }
+        format.text { render plain: "This is the text version of an email" }
+      end
     end
 
-    def multi_part_email(recipient)
-      add_logo
+    def html_email(recipient, add_logo = false)
+      add_logo_attachment if add_logo
+
       mail(
         to: recipient,
-        from: "defra-ruby-email@example.com",
-        subject: "Multi-part email",
-        body: "This is a multi-part email so calling `my_email.parts.first.body` is fine and will return this text."
-      )
+        from: FROM_ADDRESS,
+        subject: "HTML email"
+      ) do |format|
+        format.html { render html: "<h1>This is the html version of an email</h1>".html_safe }
+      end
+    end
+
+    def text_email(recipient, add_logo = false)
+      add_logo_attachment if add_logo
+
+      mail(
+        to: recipient,
+        from: FROM_ADDRESS,
+        subject: "Text email"
+      ) do |format|
+        format.text { render plain: "This is the text version of an email" }
+      end
     end
 
     private
 
-    def add_logo
+    def add_logo_attachment
       path = "/app/assets/images/defra_ruby_email/govuk_logotype_email.png"
 
       full_path = File.join(Rails.root, path)

--- a/lib/defra_ruby_email/last_email_cache.rb
+++ b/lib/defra_ruby_email/last_email_cache.rb
@@ -20,18 +20,29 @@ module DefraRubyEmail
       EMAIL_ATTRIBUTES.each do |attribute|
         message_hash[attribute] = last_email.public_send(attribute)
       end
-      message_hash[:body] = body
+      message_hash[:body] = email_body
       message_hash[:attachments] = last_email.attachments.map(&:filename)
 
       JSON.generate(last_email: message_hash)
     end
 
-    def body
-      body = last_email&.parts&.first&.body&.to_s
+    # If you've set multipart emails then you'll have both a text and a html
+    # version (determined by adding the relevant erb views). If you do so then
+    # `my_mail.parts.length` will at least equal 2. If you only have one of them
+    # e.g. just a text version then parts doesn't get populated.
+    #
+    # However any attachments will cause ActionMailer to use parts. So for example
+    # if we have a text only email with an attached image, then parts will be of
+    # length 2; one being the content and the other being the attachment.
+    #
+    # To cater for all possibilities we have this method to grab the body content
+    # https://guides.rubyonrails.org/action_mailer_basics.html#sending-multipart-emails
+    # https://stackoverflow.com/a/15818886
+    def email_body
+      part_to_use = last_email.text_part || last_email.html_part || last_email
 
-      body ||= last_email.body.to_s
-
-      body
+      # return the message body without the header information
+      part_to_use.body.decoded
     end
   end
 end

--- a/spec/lib/last_email_cache_spec.rb
+++ b/spec/lib/last_email_cache_spec.rb
@@ -205,7 +205,7 @@ module DefraRubyEmail
         it "extracts the plain text body content" do
           result = JSON.parse(instance.last_email_json)
 
-          expect(result["last_email"]["body"]).to start_with("This is a basic text email")
+          expect(result["last_email"]["body"]).to start_with("This is the text version of an email")
         end
 
         it "contains the details of the last email sent" do

--- a/spec/lib/last_email_cache_spec.rb
+++ b/spec/lib/last_email_cache_spec.rb
@@ -27,56 +27,12 @@ module DefraRubyEmail
         end
       end
 
-      context "when an email has been sent" do
+      context "when a basic email is sent" do
         let(:recipient) { "test@example.com" }
         let(:expected_keys) { %w[date from to bcc cc reply_to subject body attachments] }
 
-        context "and its a multi-part email" do
-          before(:each) do
-            TestMailer.multi_part_email(recipient).deliver_now
-          end
-
-          it "returns a JSON string" do
-            result = instance.last_email_json
-
-            expect(result).to be_a(String)
-            expect { JSON.parse(result) }.to_not raise_error
-          end
-
-          it "contains the attributes of the email" do
-            result = JSON.parse(instance.last_email_json)
-
-            expect(result["last_email"].keys).to match_array(expected_keys)
-          end
-        end
-
-        context "and its a basic email" do
-          before(:each) do
-            TestMailer.basic_email(recipient).deliver_now
-          end
-
-          it "returns a JSON string" do
-            result = instance.last_email_json
-
-            expect(result).to be_a(String)
-            expect { JSON.parse(result) }.to_not raise_error
-          end
-
-          it "contains the attributes of the email" do
-            result = JSON.parse(instance.last_email_json)
-
-            expect(result["last_email"].keys).to match_array(expected_keys)
-          end
-        end
-
-        context "when multiple emails have been sent" do
-          before(:each) do
-            TestMailer.basic_email(first_recipient).deliver_now
-            TestMailer.basic_email(second_recipient).deliver_now
-          end
-
-          let(:first_recipient) { "test@example.com" }
-          let(:second_recipient) { "joe.bloggs@example.com" }
+        context "and it is formatted as plain text" do
+          before(:each) { TestMailer.text_email(recipient).deliver_now }
 
           it "returns a JSON string" do
             result = instance.last_email_json
@@ -91,15 +47,173 @@ module DefraRubyEmail
             expect(result["last_email"].keys).to match_array(expected_keys)
           end
 
-          it "contains the details of the last email sent" do
+          it "extracts the plain text body content" do
             result = JSON.parse(instance.last_email_json)
 
-            expect(result["last_email"]["to"]).to eq([second_recipient])
+            expect(result["last_email"]["body"]).to start_with("This is the text version of an email")
           end
         end
 
+        context "and it is formatted as html" do
+          before(:each) { TestMailer.html_email(recipient).deliver_now }
+
+          it "returns a JSON string" do
+            result = instance.last_email_json
+
+            expect(result).to be_a(String)
+            expect { JSON.parse(result) }.to_not raise_error
+          end
+
+          it "contains the attributes of the email" do
+            result = JSON.parse(instance.last_email_json)
+
+            expect(result["last_email"].keys).to match_array(expected_keys)
+          end
+
+          it "extracts the html body content" do
+            result = JSON.parse(instance.last_email_json)
+
+            expect(result["last_email"]["body"]).to start_with("<h1>This is the html version of an email</h1>")
+          end
+        end
+      end
+
+      # Multi-part essentially means the email contains more than 2 elements. An
+      # element can be a HTML version, and plain text version, and an
+      # attachment. If it contains at least 2 of these it will be sent as a
+      # multipart email
+      context "when a multi-part email is sent" do
+        let(:recipient) { "test@example.com" }
+        let(:expected_keys) { %w[date from to bcc cc reply_to subject body attachments] }
+
+        context "and it contains both a html and text version" do
+          before(:each) { TestMailer.multipart_email(recipient).deliver_now }
+
+          it "returns a JSON string" do
+            result = instance.last_email_json
+
+            expect(result).to be_a(String)
+            expect { JSON.parse(result) }.to_not raise_error
+          end
+
+          it "contains the attributes of the email" do
+            result = JSON.parse(instance.last_email_json)
+
+            expect(result["last_email"].keys).to match_array(expected_keys)
+          end
+
+          it "extracts the plain text body content" do
+            result = JSON.parse(instance.last_email_json)
+
+            expect(result["last_email"]["body"]).to start_with("This is the text version of an email")
+          end
+        end
+
+        context "and contains both a html and text version plus an attachment" do
+          before(:each) { TestMailer.multipart_email(recipient, true).deliver_now }
+
+          it "returns a JSON string" do
+            result = instance.last_email_json
+
+            expect(result).to be_a(String)
+            expect { JSON.parse(result) }.to_not raise_error
+          end
+
+          it "contains the attributes of the email" do
+            result = JSON.parse(instance.last_email_json)
+
+            expect(result["last_email"].keys).to match_array(expected_keys)
+          end
+
+          it "extracts the plain text body content" do
+            result = JSON.parse(instance.last_email_json)
+
+            expect(result["last_email"]["body"]).to start_with("This is the text version of an email")
+          end
+        end
+
+        context "but it just contains a plain text part and an attachment" do
+          before(:each) { TestMailer.text_email(recipient, true).deliver_now }
+
+          it "returns a JSON string" do
+            result = instance.last_email_json
+
+            expect(result).to be_a(String)
+            expect { JSON.parse(result) }.to_not raise_error
+          end
+
+          it "contains the attributes of the email" do
+            result = JSON.parse(instance.last_email_json)
+
+            expect(result["last_email"].keys).to match_array(expected_keys)
+          end
+
+          it "extracts the plain text body content" do
+            result = JSON.parse(instance.last_email_json)
+
+            expect(result["last_email"]["body"]).to start_with("This is the text version of an email")
+          end
+        end
+
+        context "but it just contains a html part and an attachment" do
+          before(:each) { TestMailer.html_email(recipient, true).deliver_now }
+
+          it "returns a JSON string" do
+            result = instance.last_email_json
+
+            expect(result).to be_a(String)
+            expect { JSON.parse(result) }.to_not raise_error
+          end
+
+          it "contains the attributes of the email" do
+            result = JSON.parse(instance.last_email_json)
+
+            expect(result["last_email"].keys).to match_array(expected_keys)
+          end
+
+          it "extracts the html body content" do
+            result = JSON.parse(instance.last_email_json)
+
+            expect(result["last_email"]["body"]).to start_with("<h1>This is the html version of an email</h1>")
+          end
+        end
+      end
+
+      context "when multiple emails have been sent" do
+        before(:each) do
+          TestMailer.text_email(first_recipient).deliver_now
+          TestMailer.text_email(second_recipient).deliver_now
+        end
+
+        let(:expected_keys) { %w[date from to bcc cc reply_to subject body attachments] }
+        let(:first_recipient) { "test@example.com" }
+        let(:second_recipient) { "joe.bloggs@example.com" }
+
+        it "returns a JSON string" do
+          result = instance.last_email_json
+
+          expect(result).to be_a(String)
+          expect { JSON.parse(result) }.to_not raise_error
+        end
+
+        it "contains the attributes of the email" do
+          result = JSON.parse(instance.last_email_json)
+
+          expect(result["last_email"].keys).to match_array(expected_keys)
+        end
+
+        it "extracts the plain text body content" do
+          result = JSON.parse(instance.last_email_json)
+
+          expect(result["last_email"]["body"]).to start_with("This is a basic text email")
+        end
+
+        it "contains the details of the last email sent" do
+          result = JSON.parse(instance.last_email_json)
+
+          expect(result["last_email"]["to"]).to eq([second_recipient])
+        end
       end
     end
-
   end
 end

--- a/spec/requests/last_email_spec.rb
+++ b/spec/requests/last_email_spec.rb
@@ -11,7 +11,7 @@ module DefraRubyEmail
     context "when mocks are enabled" do
       before(:each) do
         Helpers::Configuration.prep_for_tests
-        TestMailer.basic_email("test@example.com").deliver_now
+        TestMailer.text_email("test@example.com").deliver_now
       end
 
       it "returns a JSON response with a 200 code containing details of the last email sent" do


### PR DESCRIPTION
In PR #3 where we added the `LastEmailCache` class, we included logic to handle multi-part and standard emails.

To be honest, part of this was due to a memory of having to code for something similar in one of our other projects. We have since tracked the [change we made to WCR frontend](https://github.com/DEFRA/waste-carriers-frontend/pull/228) down. The possible scenario we need to cater for is even more complex.

So this change is about taking the lessons learned in that PR and applying them to our engine.