### PR TITLE
Switch to SonarCloud from CodeClimate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,34 +1,24 @@
-env:
-  global:
-    - CC_TEST_REPORTER_ID=c5eef97cd54083d942812093751a1fe385361f9bb36606ced539a93c429bfe3b
+dist: trusty
+
+addons:
+  sonarcloud:
+    organization: "defra"
 
 language: ruby
 rvm: 2.4.2
 cache: bundler
 
-# Travis CI clones repositories to a depth of 50 commits, which is only really
-# useful if you are performing git operations.
-# https://docs.travis-ci.com/user/customizing-the-build/#Git-Clone-Depth
+# Travis CI uses shallow clone to speed up build times, but a truncated SCM
+# history may cause issues when SonarCloud computes blame data. To avoid this,
+# you can access the full SCM history with `depth: false`
 git:
-  depth: 3
+  depth: false
 
 before_install:
   - export TZ=UTC
   - gem install -v 1.17.3 bundler --no-rdoc --no-ri
 
-before_script:
-  # Setup to support the CodeClimate test coverage submission
-  # As per CodeClimate's documentation, they suggest only running
-  # ./cc-test-reporter commands on travis-ci push builds only. Hence we wrap all
-  # the codeclimate test coverage related commands in a check that tests if we
-  # are in a pull request or not.
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then chmod +x ./cc-test-reporter; fi
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter before-build; fi
-  # Run rubocop. It's installed as a dependency (hence no install step) as this
-  # allows projects to control the version they are using (rather than getting)
-  # surprise build failures.
-  - bundle exec rubocop
-
-after_script:
-  - if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT; fi
+script:
+  - bundle exec rubocop --format=json --out=rubocop-result.json
+  - bundle exec rspec
+  - sonar-scanner

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Defra Ruby Email
 
 [![Build Status](https://travis-ci.com/DEFRA/defra-ruby-email.svg?branch=master)](https://travis-ci.com/DEFRA/defra-ruby-email)
-[![Maintainability](https://api.codeclimate.com/v1/badges/0eb068e0b0ec99debf88/maintainability)](https://codeclimate.com/github/DEFRA/defra-ruby-email/maintainability)
-[![Test Coverage](https://api.codeclimate.com/v1/badges/0eb068e0b0ec99debf88/test_coverage)](https://codeclimate.com/github/DEFRA/defra-ruby-email/test_coverage)
+[![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_defra-ruby-email&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=DEFRA_defra-ruby-email)
+[![Coverage](https://sonarcloud.io/api/project_badges/measure?project=DEFRA_defra-ruby-email&metric=coverage)](https://sonarcloud.io/dashboard?id=DEFRA_defra-ruby-email)
 [![security](https://hakiri.io/github/DEFRA/defra-ruby-email/master.svg)](https://hakiri.io/github/DEFRA/defra-ruby-email/master)
 [![Gem Version](https://badge.fury.io/rb/defra_ruby_email.svg)](https://badge.fury.io/rb/defra_ruby_email)
 [![Licence](https://img.shields.io/badge/Licence-OGLv3-blue.svg)](http://www.nationalarchives.gov.uk/doc/open-government-licence/version/3)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,30 @@
+# Project key is required. You'll find it in the SonarCloud UI
+sonar.projectKey=DEFRA_defra-ruby-email
+sonar.organization=defra
+
+# This is the name and version displayed in the SonarCloud UI
+sonar.projectName=defra-ruby-alert
+sonar.projectVersion=0.2.0
+
+# This will add the same links in the SonarCloud UI
+sonar.links.homepage=https://github.com/DEFRA/defra-ruby-email
+sonar.links.ci=https://travis-ci.com/DEFRA/defra-ruby-email
+sonar.links.scm=https://github.com/DEFRA/defra-ruby-email
+sonar.links.issue=https://github.com/DEFRA/ruby-services-team/issues
+
+# Path is relative to the sonar-project.properties file. Replace "\" by "/" on
+# Windows.
+# Because rails generates a number of files, and SonarCloud has no rails and
+# ruby intelligence we have found we have to specify what should be covered.
+# If we don't SonarCloud will do things like take the raw coverage data from
+# simplecov, compare that to all files ion the repo, and score 0 for all the
+# files we don't actually need to test. This severly deflates our scores and
+# means it is not consistent with our previous reporting tool CodeClimate.
+sonar.sources=./lib
+sonar.tests=./spec
+
+# Encoding of the source code. Default is default system encoding
+sonar.sourceEncoding=UTF-8
+
+sonar.ruby.coverage.reportPath=coverage/.resultset.json
+sonar.ruby.rubocop.reportPaths=rubocop-result.json


### PR DESCRIPTION
https://sonarcloud.io/organizations/defra/projects

We currently use [Code Climate](https://codeclimate.com/) for our code quality checks and test coverage analysis. However a number of Defra projects have used an internal SonarQube instance, and some public ones have been using SonarCloud (the cloud SASS version of SonarQube).

It looks like we're about to formally adopt SonarCloud and all projects will coalesce onto. So to keep on top of things and continue to be an example to others, we are working through our repos and switching them to SonarCloud.

** Notes

The figuring out of how to do this (because it wasn't straight forward!) was done in

- https://github.com/DEFRA/waste-exemptions-front-office/pull/317
- https://github.com/DEFRA/waste-exemptions-front-office/pull/318