### PR TITLE
Cache emails sent to Notify

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     defra_ruby_email (1.0.0)
+      notifications-ruby-client
       rails (~> 6.0.3.1)
       sprockets (~> 3.7.2)
 
@@ -93,6 +94,7 @@ GEM
     i18n (1.8.3)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
+    jwt (2.2.2)
     loofah (2.6.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -110,6 +112,8 @@ GEM
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (5.3.0)
+      jwt (>= 1.5, < 3)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)
@@ -206,7 +210,7 @@ GEM
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
     unicode-display_width (1.7.0)
-    websocket-driver (0.7.2)
+    websocket-driver (0.7.3)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
     zeitwerk (2.3.0)

--- a/app/controllers/defra_ruby_email/last_notify_email_controller.rb
+++ b/app/controllers/defra_ruby_email/last_notify_email_controller.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module DefraRubyEmail
+  class LastNotifyEmailController < ApplicationController
+    def show
+      render json: LastNotifyEmailCache.instance.last_notify_email_json
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,9 @@ DefraRubyEmail::Engine.routes.draw do
       to: "last_email#show",
       as: "last_email",
       constraints: ->(_request) { DefraRubyEmail.configuration.enabled? }
+
+  get "/last-notify-email",
+      to: "last_notify_email#show",
+      as: "last_notify_email",
+      constraints: ->(_request) { DefraRubyEmail.configuration.enabled? }
 end

--- a/defra_ruby_email.gemspec
+++ b/defra_ruby_email.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "defra_ruby_style"
 
+  # We want to be able to understand Notify objects
+  s.add_dependency "notifications-ruby-client"
+
   # Allows us to automatically generate the change log from the tags, issues,
   # labels and pull requests on GitHub. Added as a dependency so all dev's have
   # access to it to generate a log, and so they are using the same version.

--- a/lib/defra_ruby_email/engine.rb
+++ b/lib/defra_ruby_email/engine.rb
@@ -3,6 +3,8 @@
 require_relative "configuration"
 require_relative "last_email_cache"
 require_relative "last_email_observer"
+require_relative "last_notify_email_cache"
+require_relative "last_notify_email_observer"
 
 module DefraRubyEmail
   class Engine < ::Rails::Engine

--- a/lib/defra_ruby_email/last_notify_email_cache.rb
+++ b/lib/defra_ruby_email/last_notify_email_cache.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module DefraRubyEmail
+  class LastNotifyEmailCache
+    include Singleton
+
+    NOTIFICATION_ATTRIBUTES = %i[from_email subject body].freeze
+
+    attr_accessor :last_notify_email
+
+    # This is necessary to properly test the service functionality
+    def reset
+      @last_notify_email = nil
+    end
+
+    def last_notify_email_json
+      return JSON.generate(error: "No Notify emails sent.") unless last_notify_email.present?
+
+      message_hash = {}
+      message_hash[:body] = last_notify_email.content["body"]
+      message_hash[:from] = last_notify_email.content["from_email"]
+      message_hash[:subject] = last_notify_email.content["subject"]
+
+      JSON.generate(last_notify_email: message_hash)
+    end
+  end
+end

--- a/lib/defra_ruby_email/last_notify_email_observer.rb
+++ b/lib/defra_ruby_email/last_notify_email_observer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DefraRubyEmail
+  class LastNotifyEmailObserver
+
+    def self.delivered_notify_email(response)
+      LastNotifyEmailCache.instance.last_notify_email = response
+    end
+
+  end
+end

--- a/spec/lib/last_notify_email_cache_spec.rb
+++ b/spec/lib/last_notify_email_cache_spec.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module DefraRubyEmail
+  RSpec.describe LastNotifyEmailCache do
+    subject(:instance) { described_class.instance }
+
+    before(:each) { instance.reset }
+
+    let(:expected_keys) { %w[body from subject] }
+    let(:body) { "This is the body of a Notify email" }
+    let(:from_email) { "test@example.com" }
+    let(:subject) { "Notify email test" }
+    let(:content) do
+      {
+        "body" => body,
+        "from_email" => from_email,
+        "subject" => subject,
+      }
+    end
+    let(:notify_response) { double(:notify_response, content: content) }
+
+    describe "#last_notify_email_json" do
+      context "when the no emails have been sent" do
+        let(:expected_keys) { %w[error] }
+
+        it "returns a JSON string" do
+          result = instance.last_notify_email_json
+
+          expect(result).to be_a(String)
+          expect { JSON.parse(result) }.to_not raise_error
+        end
+
+        it "responds with an error message" do
+          result = JSON.parse(instance.last_notify_email_json)
+
+          expect(result.keys).to match_array(expected_keys)
+        end
+      end
+
+      context "when a basic email is sent" do
+        before(:each) { LastNotifyEmailObserver.delivered_notify_email(notify_response) }
+
+        it "returns a JSON string" do
+          result = instance.last_notify_email_json
+
+          expect(result).to be_a(String)
+          expect { JSON.parse(result) }.to_not raise_error
+        end
+
+        it "contains the attributes of the email" do
+          result = JSON.parse(instance.last_notify_email_json)
+
+          expect(result["last_notify_email"].keys).to match_array(expected_keys)
+        end
+
+        it "has the correct data" do
+          result = JSON.parse(instance.last_notify_email_json)
+          puts result
+
+          expect(result["last_notify_email"]["body"]).to eq(body)
+          expect(result["last_notify_email"]["from"]).to eq(from_email)
+          expect(result["last_notify_email"]["subject"]).to eq(subject)
+        end
+      end
+
+      context "when multiple Notify emails have been sent" do
+        let(:second_content) do
+          {
+            "body": body,
+            "from_email": from_email,
+            "subject": "Second test",
+          }
+        end
+        let(:second_notify_response) { double(:notify_response, content: second_content) }
+        before(:each) do
+          LastNotifyEmailObserver.delivered_notify_email(notify_response)
+          LastNotifyEmailObserver.delivered_notify_email(second_notify_response)
+        end
+
+        it "returns a JSON string" do
+          result = instance.last_notify_email_json
+
+          expect(result).to be_a(String)
+          expect { JSON.parse(result) }.to_not raise_error
+        end
+
+        it "contains the attributes of the email" do
+          result = JSON.parse(instance.last_notify_email_json)
+
+          expect(result["last_notify_email"].keys).to match_array(expected_keys)
+        end
+
+        it "has the correct data for the last email sent" do
+          result = JSON.parse(instance.last_notify_email_json)
+
+          expect(result["last_notify_email"]["body"]).to eq(body)
+          expect(result["last_notify_email"]["from"]).to eq(from_email)
+          expect(result["last_notify_email"]["subject"]).to eq("Second test")
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1206

This PR updates the last email API to also track emails being sent via Notify.

These can be accessed at /last-notify-email