### PR TITLE
Add ability to check last Notify message

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,6 +2,7 @@ PATH
   remote: .
   specs:
     defra_ruby_email (1.0.0)
+      notifications-ruby-client
       rails (~> 6.0.3.1)
       sprockets (~> 3.7.2)
 
@@ -93,6 +94,7 @@ GEM
     i18n (1.8.5)
       concurrent-ruby (~> 1.0)
     json (2.3.0)
+    jwt (2.2.2)
     loofah (2.7.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
@@ -110,6 +112,8 @@ GEM
     nio4r (2.5.4)
     nokogiri (1.10.10)
       mini_portile2 (~> 2.4.0)
+    notifications-ruby-client (5.3.0)
+      jwt (>= 1.5, < 3)
     octokit (4.18.0)
       faraday (>= 0.9)
       sawyer (~> 0.8.0, >= 0.5.3)

--- a/app/controllers/defra_ruby_email/last_notify_message_controller.rb
+++ b/app/controllers/defra_ruby_email/last_notify_message_controller.rb
@@ -3,7 +3,7 @@
 module DefraRubyEmail
   class LastNotifyMessageController < ApplicationController
     def show
-      LastNotifyMessage.instance.get_last_notify_message
+      LastNotifyMessage.instance.retrieve_last_notify_message
 
       render json: LastNotifyMessage.instance.last_notify_message_json
     end

--- a/app/controllers/defra_ruby_email/last_notify_message_controller.rb
+++ b/app/controllers/defra_ruby_email/last_notify_message_controller.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module DefraRubyEmail
+  class LastNotifyMessageController < ApplicationController
+    def show
+      LastNotifyMessage.instance.get_last_notify_message
+
+      render json: LastNotifyMessage.instance.last_notify_message_json
+    end
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,4 +5,9 @@ DefraRubyEmail::Engine.routes.draw do
       to: "last_email#show",
       as: "last_email",
       constraints: ->(_request) { DefraRubyEmail.configuration.enabled? }
+
+  get "/last-notify-message",
+      to: "last_notify_message#show",
+      as: "last_notify_message",
+      constraints: ->(_request) { DefraRubyEmail.configuration.enabled? }
 end

--- a/defra_ruby_email.gemspec
+++ b/defra_ruby_email.gemspec
@@ -28,6 +28,9 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "defra_ruby_style"
 
+  # We want to be able to make requests to Notify and understand Notify objects
+  s.add_dependency "notifications-ruby-client"
+
   # Allows us to automatically generate the change log from the tags, issues,
   # labels and pull requests on GitHub. Added as a dependency so all dev's have
   # access to it to generate a log, and so they are using the same version.

--- a/lib/defra_ruby_email/configuration.rb
+++ b/lib/defra_ruby_email/configuration.rb
@@ -3,6 +3,8 @@
 module DefraRubyEmail
   class Configuration
 
+    attr_accessor :notify_api_key
+
     def initialize
       @enable = false
     end

--- a/lib/defra_ruby_email/engine.rb
+++ b/lib/defra_ruby_email/engine.rb
@@ -3,6 +3,7 @@
 require_relative "configuration"
 require_relative "last_email_cache"
 require_relative "last_email_observer"
+require_relative "last_notify_message"
 
 module DefraRubyEmail
   class Engine < ::Rails::Engine

--- a/lib/defra_ruby_email/last_notify_message.rb
+++ b/lib/defra_ruby_email/last_notify_message.rb
@@ -15,7 +15,7 @@ module DefraRubyEmail
       @last_notify_message = nil
     end
 
-    def get_last_notify_message
+    def retrieve_last_notify_message
       client = Notifications::Client.new(DefraRubyEmail.configuration.notify_api_key)
       response = client.get_notifications
       @last_notify_message = response.collection.first

--- a/lib/defra_ruby_email/last_notify_message.rb
+++ b/lib/defra_ruby_email/last_notify_message.rb
@@ -1,0 +1,44 @@
+# frozen_string_literal: true
+
+require "notifications/client"
+
+module DefraRubyEmail
+  class LastNotifyMessage
+    include Singleton
+
+    LETTER_ATTRIBUTES = %i[line_1 line_2 line_3 line_4 line_5 line_6 postcode].freeze
+
+    attr_accessor :last_notify_message
+
+    # This is necessary to properly test the service functionality
+    def reset
+      @last_notify_message = nil
+    end
+
+    def get_last_notify_message
+      client = Notifications::Client.new(ENV["NOTIFY_API_KEY"])
+      response = client.get_notifications
+      @last_notify_message = response.collection.first
+    end
+
+    def last_notify_message_json
+      return JSON.generate(error: "No messages sent.") unless last_notify_message.present?
+
+      message_hash = {}
+      message_hash[:type] = last_notify_message.type
+
+      message_hash[:subject] = last_notify_message.subject
+      message_hash[:body] = last_notify_message.body
+      message_hash[:date] = last_notify_message.sent_at
+
+      # Email-specific attributes
+      message_hash[:to] = last_notify_message.email_address
+      # Letter-specific attributes
+      LETTER_ATTRIBUTES.each do |attribute|
+        message_hash[attribute] = last_notify_message.public_send(attribute)
+      end
+
+      JSON.generate(last_notify_message: message_hash)
+    end
+  end
+end

--- a/lib/defra_ruby_email/last_notify_message.rb
+++ b/lib/defra_ruby_email/last_notify_message.rb
@@ -26,13 +26,13 @@ module DefraRubyEmail
 
       message_hash = {}
       message_hash[:type] = last_notify_message.type
-
+      message_hash[:template] = last_notify_message.template
       message_hash[:subject] = last_notify_message.subject
       message_hash[:body] = last_notify_message.body
       message_hash[:date] = last_notify_message.sent_at
 
-      # Email-specific attributes
-      message_hash[:to] = last_notify_message.email_address
+      # Email and phone-specific attributes
+      message_hash[:to] = last_notify_message.email_address || last_notify_message.phone_number
       # Letter-specific attributes
       LETTER_ATTRIBUTES.each do |attribute|
         message_hash[attribute] = last_notify_message.public_send(attribute)

--- a/lib/defra_ruby_email/last_notify_message.rb
+++ b/lib/defra_ruby_email/last_notify_message.rb
@@ -16,7 +16,7 @@ module DefraRubyEmail
     end
 
     def get_last_notify_message
-      client = Notifications::Client.new(ENV["NOTIFY_API_KEY"])
+      client = Notifications::Client.new(DefraRubyEmail.configuration.notify_api_key)
       response = client.get_notifications
       @last_notify_message = response.collection.first
     end

--- a/spec/dummy/config/initializers/defra_ruby_email.rb
+++ b/spec/dummy/config/initializers/defra_ruby_email.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+DefraRubyEmail.configure do |configuration|
+  configuration.notify_api_key = "test"
+end

--- a/spec/lib/last_notify_message_spec.rb
+++ b/spec/lib/last_notify_message_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+module DefraRubyEmail
+  RSpec.describe LastNotifyMessage do
+    subject(:instance) { described_class.instance }
+
+    before(:each) { instance.reset }
+
+    let(:client) { double(:client, get_notifications: notifications) }
+    let(:notifications) { double(:notifications, collection: collection) }
+    let(:collection) { double(:collection, first: notification) }
+    let(:notification) do
+      double(:notification,
+             type: "email",
+             subject: "Subject",
+             body: "Body",
+             sent_at: "datetime",
+             email_address: "test@example.com",
+             line_1: nil,
+             line_2: nil,
+             line_3: nil,
+             line_4: nil,
+             line_5: nil,
+             line_6: nil,
+             postcode: nil)
+    end
+
+    let(:expected_keys) { %w[type subject body date to line_1 line_2 line_3 line_4 line_5 line_6 postcode] }
+
+    describe "#get_last_notify_message" do
+      it "makes a call to the Notify client" do
+        expect(Notifications::Client).to receive(:new).with(ENV["NOTIFY_API_KEY"]).and_return(client)
+        expect(client).to receive(:get_notifications).and_return(notifications)
+
+        expect(instance.last_notify_message).to eq(nil)
+
+        instance.get_last_notify_message
+
+        expect(instance.last_notify_message).to eq(notification)
+      end
+    end
+
+    describe "#last_notify_message_json" do
+      context "when no messages have been sent" do
+        let(:expected_keys) { %w[error] }
+
+        it "returns a JSON string" do
+          result = instance.last_notify_message_json
+
+          expect(result).to be_a(String)
+          expect { JSON.parse(result) }.to_not raise_error
+        end
+
+        it "responds with an error message" do
+          result = JSON.parse(instance.last_notify_message_json)
+
+          expect(result.keys).to match_array(expected_keys)
+        end
+      end
+
+      context "when a message has been sent" do
+        before(:each) { instance.get_last_notify_message }
+
+        it "returns a JSON string" do
+          result = instance.last_notify_message_json
+
+          expect(result).to be_a(String)
+          expect { JSON.parse(result) }.to_not raise_error
+        end
+
+        it "contains the attributes of the message" do
+          result = JSON.parse(instance.last_notify_message_json)
+
+          expect(result["last_notify_message"].keys).to match_array(expected_keys)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/last_notify_message_spec.rb
+++ b/spec/lib/last_notify_message_spec.rb
@@ -31,14 +31,14 @@ module DefraRubyEmail
 
     let(:expected_keys) { %w[type template subject body date to line_1 line_2 line_3 line_4 line_5 line_6 postcode] }
 
-    describe "#get_last_notify_message" do
+    describe "#retrieve_last_notify_message" do
       it "makes a call to the Notify client" do
         expect(Notifications::Client).to receive(:new).with(DefraRubyEmail.configuration.notify_api_key).and_return(client)
         expect(client).to receive(:get_notifications).and_return(notifications)
 
         expect(instance.last_notify_message).to eq(nil)
 
-        instance.get_last_notify_message
+        instance.retrieve_last_notify_message
 
         expect(instance.last_notify_message).to eq(notification)
       end

--- a/spec/lib/last_notify_message_spec.rb
+++ b/spec/lib/last_notify_message_spec.rb
@@ -14,10 +14,12 @@ module DefraRubyEmail
     let(:notification) do
       double(:notification,
              type: "email",
+             template: "template",
              subject: "Subject",
              body: "Body",
              sent_at: "datetime",
              email_address: "test@example.com",
+             phone_number: nil,
              line_1: nil,
              line_2: nil,
              line_3: nil,
@@ -27,7 +29,7 @@ module DefraRubyEmail
              postcode: nil)
     end
 
-    let(:expected_keys) { %w[type subject body date to line_1 line_2 line_3 line_4 line_5 line_6 postcode] }
+    let(:expected_keys) { %w[type template subject body date to line_1 line_2 line_3 line_4 line_5 line_6 postcode] }
 
     describe "#get_last_notify_message" do
       it "makes a call to the Notify client" do

--- a/spec/lib/last_notify_message_spec.rb
+++ b/spec/lib/last_notify_message_spec.rb
@@ -33,7 +33,7 @@ module DefraRubyEmail
 
     describe "#get_last_notify_message" do
       it "makes a call to the Notify client" do
-        expect(Notifications::Client).to receive(:new).with(ENV["NOTIFY_API_KEY"]).and_return(client)
+        expect(Notifications::Client).to receive(:new).with(DefraRubyEmail.configuration.notify_api_key).and_return(client)
         expect(client).to receive(:get_notifications).and_return(notifications)
 
         expect(instance.last_notify_message).to eq(nil)
@@ -63,7 +63,9 @@ module DefraRubyEmail
       end
 
       context "when a message has been sent" do
-        before(:each) { instance.get_last_notify_message }
+        before(:each) do
+          instance.last_notify_message = notification
+        end
 
         it "returns a JSON string" do
           result = instance.last_notify_message_json

--- a/spec/requests/last_notify_message_spec.rb
+++ b/spec/requests/last_notify_message_spec.rb
@@ -1,0 +1,76 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+require "notifications/client"
+
+module DefraRubyEmail
+  RSpec.describe "LastNotifyMessage", type: :request do
+    after(:all) { Helpers::Configuration.reset_for_tests }
+
+    let(:path) { "/defra_ruby_email/last-notify-message" }
+
+    let(:client) { double(:client, get_notifications: notifications) }
+    let(:notifications) { double(:notifications, collection: collection) }
+    let(:collection) { double(:collection, first: notification) }
+    let(:notification) do
+      double(:notification,
+             type: "email",
+             subject: "Subject",
+             body: "Body",
+             sent_at: "datetime",
+             email_address: "test@example.com",
+             line_1: nil,
+             line_2: nil,
+             line_3: nil,
+             line_4: nil,
+             line_5: nil,
+             line_6: nil,
+             postcode: nil)
+    end
+
+    context "when the API is enabled" do
+      let(:expected_data) do
+        {
+          last_notify_message: {
+            type: "email",
+            subject: "Subject",
+            body: "Body",
+            date: "datetime",
+            to: "test@example.com",
+            line_1: nil,
+            line_2: nil,
+            line_3: nil,
+            line_4: nil,
+            line_5: nil,
+            line_6: nil,
+            postcode: nil
+          }
+        }.to_json
+      end
+
+      before(:each) do
+        Helpers::Configuration.prep_for_tests
+
+        expect(Notifications::Client).to receive(:new).with(ENV["NOTIFY_API_KEY"]).and_return(client)
+        expect(client).to receive(:get_notifications).and_return(notifications)
+      end
+
+      it "returns a JSON response with a 200 code containing details of the last Notify message sent" do
+        get path
+
+        expect(response.content_type).to eq("application/json")
+        expect(response.code).to eq("200")
+
+        expect(response.body).to eq(expected_data)
+      end
+    end
+
+    context "when the API is disabled" do
+      before(:all) { DefraRubyEmail.configuration.enable = false }
+
+      it "cannot load the page" do
+        expect { get path }.to raise_error(ActionController::RoutingError)
+      end
+    end
+  end
+end

--- a/spec/requests/last_notify_message_spec.rb
+++ b/spec/requests/last_notify_message_spec.rb
@@ -9,6 +9,7 @@ module DefraRubyEmail
 
     let(:path) { "/defra_ruby_email/last-notify-message" }
 
+    let(:notify_api_key) { "hello-i-am-a-key" }
     let(:client) { double(:client, get_notifications: notifications) }
     let(:notifications) { double(:notifications, collection: collection) }
     let(:collection) { double(:collection, first: notification) }
@@ -51,7 +52,9 @@ module DefraRubyEmail
       before(:each) do
         Helpers::Configuration.prep_for_tests
 
-        expect(Notifications::Client).to receive(:new).with(ENV["NOTIFY_API_KEY"]).and_return(client)
+        expect(DefraRubyEmail.configuration).to receive(:notify_api_key).and_return(notify_api_key)
+
+        expect(Notifications::Client).to receive(:new).with(notify_api_key).and_return(client)
         expect(client).to receive(:get_notifications).and_return(notifications)
       end
 

--- a/spec/requests/last_notify_message_spec.rb
+++ b/spec/requests/last_notify_message_spec.rb
@@ -16,10 +16,12 @@ module DefraRubyEmail
     let(:notification) do
       double(:notification,
              type: "email",
+             template: "template",
              subject: "Subject",
              body: "Body",
              sent_at: "datetime",
              email_address: "test@example.com",
+             phone_number: nil,
              line_1: nil,
              line_2: nil,
              line_3: nil,
@@ -34,6 +36,7 @@ module DefraRubyEmail
         {
           last_notify_message: {
             type: "email",
+            template: "template",
             subject: "Subject",
             body: "Body",
             date: "datetime",


### PR DESCRIPTION
https://eaflood.atlassian.net/browse/RUBY-1206

This PR adds the ability to visit /last-notify-message in the API and get a JSON response with data about the last message that Notify received for this API key.

Whenever this route is hit, we send a message to Notify to retrieve the latest version of this data.