### PR TITLE
Enable Rails 6.0/6.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     defra_ruby_email (1.1.0)
       notifications-ruby-client
-      rails (~> 6.0.3.1)
+      rails (~> 6.0)
       sprockets (~> 3.7.2)
 
 GEM

--- a/defra_ruby_email.gemspec
+++ b/defra_ruby_email.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["spec/**/*"]
 
-  s.add_dependency "rails", "~> 6.0.3.1"
+  s.add_dependency "rails", "~> 6.0"
   # Pin version of sprockers. Rails 4.2.11.3 seems to want to bring in version
   # 4.0.0 of sprockets (even though that version is not directly referenced in
   # the rails gemspec or Gemfile.lock) however that requires ruby 2.5 as a

--- a/spec/requests/last_email_spec.rb
+++ b/spec/requests/last_email_spec.rb
@@ -17,7 +17,7 @@ module DefraRubyEmail
       it "returns a JSON response with a 200 code containing details of the last email sent" do
         get path
 
-        expect(response.content_type).to eq("application/json")
+        expect(response.media_type).to eq("application/json")
         expect(response.code).to eq("200")
         expect(response.body).to eq(LastEmailCache.instance.last_email_json)
       end

--- a/spec/requests/last_notify_message_spec.rb
+++ b/spec/requests/last_notify_message_spec.rb
@@ -64,7 +64,7 @@ module DefraRubyEmail
       it "returns a JSON response with a 200 code containing details of the last Notify message sent" do
         get path
 
-        expect(response.content_type).to eq("application/json")
+        expect(response.media_type).to eq("application/json")
         expect(response.code).to eq("200")
 
         expect(response.body).to eq(expected_data)


### PR DESCRIPTION
Note: this will only necessary for the upgrade from Rails 6.0 to 6.1

